### PR TITLE
Add support for TLSv1.2 for versions before Net45

### DIFF
--- a/EasyPost/Security.cs
+++ b/EasyPost/Security.cs
@@ -6,7 +6,7 @@ namespace EasyPost {
 #if NET45
             return SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 #else
-            return SecurityProtocolType.Tls;
+            return (SecurityProtocolType)0x00000C00;
 #endif
         }
     }


### PR DESCRIPTION
This will allow versions before Net45 support TLSv1.2 without requiring clients to run the Net45 build