### PR TITLE
Add support for TLSv1.2 for versions before Net45

### DIFF
--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -15,7 +15,7 @@ namespace EasyPost {
         internal ClientConfiguration configuration;
 
         internal Client(ClientConfiguration clientConfiguration) {
-            System.Net.ServicePointManager.SecurityProtocol = Security.GetProtocol();
+            System.Net.ServicePointManager.SecurityProtocol |= Security.GetProtocol();
 
             if (clientConfiguration == null) throw new ArgumentNullException("clientConfiguration");
             configuration = clientConfiguration;


### PR DESCRIPTION
This small change ensures that other supported protocols aren't replaced, but that TLSv1.2 is in addition.